### PR TITLE
Make profile view cell empty area also tappable

### DIFF
--- a/WMO/Tab/Profile/ProfileView.swift
+++ b/WMO/Tab/Profile/ProfileView.swift
@@ -124,6 +124,7 @@ struct ProfileView: View {
   func entryRow(_ entry: SettingEntry, toggle: Binding<Bool>? = nil) -> some View {
     NavigationLink(destination: entryView(entry)) {
       entryRowView(entry)
+        .contentShape(Rectangle())
     }
     .navigationBarTitle("") // remove back button title
   }


### PR DESCRIPTION
As title, area with no texts are not tappable before

https://github.com/ukiyoevega/WomenOverseas/assets/141540701/8995c2aa-2971-45ce-9b22-b893f8f4278e

but after add this line the empty area is tappable 

https://github.com/ukiyoevega/WomenOverseas/assets/141540701/781ec247-f5d3-40ea-9dd0-ef0223c80665

